### PR TITLE
Removed recusrive calls and made other minor changes

### DIFF
--- a/rotate-matrix.js
+++ b/rotate-matrix.js
@@ -8,31 +8,40 @@
       n = 1;
     } else if (n === 0) {
       return m;
+    } else {
+      n = n % 4;
     }
 
-    var mt = [];
+    var prevMt, mt;
+    prevMt = mt = m;
 
-    for (var i = 0, cl = m.length; i < cl; i++) {
-      for (var j = 0, rl = m[i].length; j < rl; j++) {
-        if (cl !== rl) {
-          return [];
+    while (n !== 0) {
+      mt = [];
+
+      for (var i = 0, cl = prevMt.length; i < cl; i++) {
+        for (var j = 0, rl = prevMt[i].length; j < rl; j++) {
+          if (cl !== rl) {
+            return [];
+          }
+
+          mt[i] = mt[i] || [];
+          mt[i][j] = prevMt[j][i];
         }
 
-        mt[i] = mt[i] || [];
-        mt[i][j] = m[j][i];
+        if (n > 0) {
+          mt[i] = mt[i].reverse();
+        }
       }
 
-      if (n > 0) {
-        mt[i] = mt[i].reverse();
+      if (n < 0) {
+        mt.reverse();
+        n++;
       }
-    }
-
-    if (n < 0) {
-      mt.reverse();
-    }
-
-    while(n > 0 ? n-- : n++) {
-      mt = rotateMatrix(mt, n);
+      else {
+        n--;
+      }
+      
+      prevMt = mt;
     }
 
     return mt;

--- a/test/rotate-matrix.js
+++ b/test/rotate-matrix.js
@@ -4,7 +4,7 @@ const rotateMatrix = require('../rotate-matrix');
 test('rotateMatrix', function (t) {
   'use strict';
 
-  t.plan(10);
+  t.plan(12);
 
   t.deepEqual(rotateMatrix(), []);
   t.deepEqual(rotateMatrix(''), []);
@@ -44,6 +44,26 @@ test('rotateMatrix', function (t) {
     [9,8,7],
     [6,5,4],
     [3,2,1]
+  ]);
+
+  t.deepEqual(rotateMatrix([
+    [1,2,3],
+    [4,5,6],
+    [7,8,9]
+  ], 3), [
+    [3,6,9],
+    [2,5,8],
+    [1,4,7]
+  ]);
+
+  t.deepEqual(rotateMatrix([
+    [1,2,3],
+    [4,5,6],
+    [7,8,9]
+  ], -3), [
+    [7,4,1],
+    [8,5,2],
+    [9,6,3]
   ]);
 
   t.deepEqual(rotateMatrix([


### PR DESCRIPTION
Hello!
I needed to rotate matrices, but I'm too lazy to implement it myself and found your library.
What I exactly wanted was to rotate matrices by 90, 180 and 270 degrees counter-clockwise. But I realized that the library was doing it wrong in case of 270 degrees - it rotated by 360 degrees instead.
So I ended up looking at your sources and found that recursive calls cause this issue. I replaced them with a simple `while` loop, added a couple of unit-tests, and it goes well now!
Glad to help!

Best regards, 
Mikhail Dudin